### PR TITLE
target ruby 2.6, update IndentArray and IndentHash

### DIFF
--- a/rubocop/rubocop_trailhead.yml
+++ b/rubocop/rubocop_trailhead.yml
@@ -16,7 +16,7 @@ AllCops:
     - 'db/migrate/*'
     - 'vendor/*'
 
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Metrics/LineLength:
   Max: 120
@@ -90,10 +90,10 @@ Style/RegexpLiteral:
 Style/Documentation:
   Enabled: false
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Style/ClassAndModuleChildren:


### PR DESCRIPTION
* target Ruby 2.6
* update to Rubocop's new name for `Layout/IndentArray`, `Layout/IndentFirstArrayElement`
* update to Rubocop's new name for `Layout/IndentHash`, `Layout/IndentFirstHashElement